### PR TITLE
[MI-2948] Fixed the issue that link and unlink commands are available for all users

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -127,8 +127,20 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 }
 
 func (p *Plugin) executeLinkCommand(c *plugin.Context, args *model.CommandArgs, parameters []string) (*model.CommandResponse, *model.AppError) {
-	if !p.IsSystemAdmin(args.UserId) && !p.IsChannelAdmin(args.UserId, args.ChannelId) {
-		return p.cmdError(args.UserId, args.ChannelId, "This command can be run only by channel and system admins.")
+	isSysAdmin, err := p.IsSystemAdmin(args.UserId)
+	if err != nil {
+		return p.cmdError(args.UserId, args.ChannelId, "Something went wrong.")
+	}
+
+	if !isSysAdmin {
+		isChannelAdmin, err := p.IsChannelAdmin(args.UserId, args.ChannelId)
+		if err != nil {
+			return p.cmdError(args.UserId, args.ChannelId, "Something went wrong.")
+		}
+
+		if !isChannelAdmin {
+			return p.cmdError(args.UserId, args.ChannelId, "This command can be run only by channel and system admins.")
+		}
 	}
 
 	if len(parameters) < 2 {
@@ -185,8 +197,20 @@ func (p *Plugin) executeLinkCommand(c *plugin.Context, args *model.CommandArgs, 
 }
 
 func (p *Plugin) executeUnlinkCommand(c *plugin.Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
-	if !p.IsSystemAdmin(args.UserId) && !p.IsChannelAdmin(args.UserId, args.ChannelId) {
-		return p.cmdError(args.UserId, args.ChannelId, "This command can be run only by channel and system admins.")
+	isSysAdmin, err := p.IsSystemAdmin(args.UserId)
+	if err != nil {
+		return p.cmdError(args.UserId, args.ChannelId, "Something went wrong.")
+	}
+
+	if !isSysAdmin {
+		isChannelAdmin, err := p.IsChannelAdmin(args.UserId, args.ChannelId)
+		if err != nil {
+			return p.cmdError(args.UserId, args.ChannelId, "Something went wrong.")
+		}
+
+		if !isChannelAdmin {
+			return p.cmdError(args.UserId, args.ChannelId, "This command can be run only by channel and system admins.")
+		}
 	}
 
 	channel, appErr := p.API.GetChannel(args.ChannelId)
@@ -200,7 +224,7 @@ func (p *Plugin) executeUnlinkCommand(c *plugin.Context, args *model.CommandArgs
 		return p.cmdError(args.UserId, args.ChannelId, "Unable to unlink the channel, you has to be a channel admin to unlink it.")
 	}
 
-	err := p.store.DeleteLinkByChannelID(channel.Id)
+	err = p.store.DeleteLinkByChannelID(channel.Id)
 	if err != nil {
 		return p.cmdError(args.UserId, args.ChannelId, "Unable to delete link.")
 	}

--- a/server/command.go
+++ b/server/command.go
@@ -69,9 +69,11 @@ func getAutocompleteData() *model.AutocompleteData {
 	cmd.AddCommand(disconnect)
 
 	connectBot := model.NewAutocompleteData("connect-bot", "", "Connect the bot account (only system admins can do this)")
+	connectBot.RoleID = model.SystemAdminRoleId
 	cmd.AddCommand(connectBot)
 
 	disconnectBot := model.NewAutocompleteData("disconnect-bot", "", "Disconnect the bot account (only system admins can do this)")
+	disconnectBot.RoleID = model.SystemAdminRoleId
 	cmd.AddCommand(disconnectBot)
 
 	return cmd
@@ -125,6 +127,10 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 }
 
 func (p *Plugin) executeLinkCommand(c *plugin.Context, args *model.CommandArgs, parameters []string) (*model.CommandResponse, *model.AppError) {
+	if !p.IsSystemAdmin(args.UserId) && !p.IsChannelAdmin(args.UserId, args.ChannelId) {
+		return p.cmdError(args.UserId, args.ChannelId, "This command can be run only by channel and system admins.")
+	}
+
 	if len(parameters) < 2 {
 		return p.cmdError(args.UserId, args.ChannelId, "Invalid link command, please pass the MS Teams team id and channel id as parameters.")
 	}
@@ -179,6 +185,10 @@ func (p *Plugin) executeLinkCommand(c *plugin.Context, args *model.CommandArgs, 
 }
 
 func (p *Plugin) executeUnlinkCommand(c *plugin.Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
+	if !p.IsSystemAdmin(args.UserId) && !p.IsChannelAdmin(args.UserId, args.ChannelId) {
+		return p.cmdError(args.UserId, args.ChannelId, "This command can be run only by channel and system admins.")
+	}
+
 	channel, appErr := p.API.GetChannel(args.ChannelId)
 	if appErr != nil {
 		return p.cmdError(args.UserId, args.ChannelId, "Unable to get the current channel information.")

--- a/server/command.go
+++ b/server/command.go
@@ -133,7 +133,8 @@ func (p *Plugin) executeLinkCommand(c *plugin.Context, args *model.CommandArgs, 
 	}
 
 	if !isSysAdmin {
-		isChannelAdmin, err := p.IsChannelAdmin(args.UserId, args.ChannelId)
+		var isChannelAdmin bool
+		isChannelAdmin, err = p.IsChannelAdmin(args.UserId, args.ChannelId)
 		if err != nil {
 			return p.cmdError(args.UserId, args.ChannelId, "Something went wrong.")
 		}
@@ -203,7 +204,8 @@ func (p *Plugin) executeUnlinkCommand(c *plugin.Context, args *model.CommandArgs
 	}
 
 	if !isSysAdmin {
-		isChannelAdmin, err := p.IsChannelAdmin(args.UserId, args.ChannelId)
+		var isChannelAdmin bool
+		isChannelAdmin, err = p.IsChannelAdmin(args.UserId, args.ChannelId)
 		if err != nil {
 			return p.cmdError(args.UserId, args.ChannelId, "Something went wrong.")
 		}

--- a/server/util.go
+++ b/server/util.go
@@ -5,6 +5,7 @@ import "github.com/mattermost/mattermost-server/v6/model"
 func (p *Plugin) IsSystemAdmin(userID string) (bool, error) {
 	user, appErr := p.API.GetUser(userID)
 	if appErr != nil {
+		p.API.LogError("Unable to get the user", "UserID", userID, "Error", appErr.Error())
 		return false, appErr
 	}
 
@@ -14,6 +15,7 @@ func (p *Plugin) IsSystemAdmin(userID string) (bool, error) {
 func (p *Plugin) IsChannelAdmin(userID, channelID string) (bool, error) {
 	channelMember, err := p.API.GetChannelMember(channelID, userID)
 	if err != nil {
+		p.API.LogError("Unable to get the channel member", "UserID", userID, "ChannelID", channelID, "Error", err.Error())
 		return false, err
 	}
 

--- a/server/util.go
+++ b/server/util.go
@@ -1,0 +1,21 @@
+package main
+
+import "github.com/mattermost/mattermost-server/v6/model"
+
+func (p *Plugin) IsSystemAdmin(userID string) bool {
+	user, appErr := p.API.GetUser(userID)
+	if appErr != nil {
+		return false
+	}
+
+	return user.IsInRole(model.SystemAdminRoleId)
+}
+
+func (p *Plugin) IsChannelAdmin(userID, channelID string) bool {
+	channelMember, err := p.API.GetChannelMember(channelID, userID)
+	if err != nil {
+		return false
+	}
+
+	return channelMember.SchemeAdmin
+}

--- a/server/util.go
+++ b/server/util.go
@@ -2,20 +2,20 @@ package main
 
 import "github.com/mattermost/mattermost-server/v6/model"
 
-func (p *Plugin) IsSystemAdmin(userID string) bool {
+func (p *Plugin) IsSystemAdmin(userID string) (bool, error) {
 	user, appErr := p.API.GetUser(userID)
 	if appErr != nil {
-		return false
+		return false, appErr
 	}
 
-	return user.IsInRole(model.SystemAdminRoleId)
+	return user.IsInRole(model.SystemAdminRoleId), nil
 }
 
-func (p *Plugin) IsChannelAdmin(userID, channelID string) bool {
+func (p *Plugin) IsChannelAdmin(userID, channelID string) (bool, error) {
 	channelMember, err := p.API.GetChannelMember(channelID, userID)
 	if err != nil {
-		return false
+		return false, err
 	}
 
-	return channelMember.SchemeAdmin
+	return channelMember.SchemeAdmin, nil
 }


### PR DESCRIPTION
Created two utils for checking if a user is channel admin or system admin
Added the logic for hiding connect and disconnect bot commands for all except system admins